### PR TITLE
Update Origami.pm

### DIFF
--- a/Origami/Origami.pm
+++ b/Origami/Origami.pm
@@ -644,9 +644,6 @@ sub new {
       $current_layer->{id}=$node->getAttribute('id');
       $current_layer->{transform}=$node->getAttribute('transform');
 
-      
-      $current_layer->{transform} = 0;
-      
           defined $current_layer->{transform}
       and $current_layer->{transform} = $current_layer->{transform} =~ /^translate\($re_num,($re_num)\)$/ ? $1 : 0;
           


### PR DESCRIPTION
Corrected bug :

if current layer transform attribute was ignored, resulting in wrong Y axis guide origin if document format (size or orientation) is mofified.